### PR TITLE
Pass the result aggregator to the task error callback.

### DIFF
--- a/src/AbstractRunner.php
+++ b/src/AbstractRunner.php
@@ -311,7 +311,7 @@ abstract class AbstractRunner implements RunnerInterface {
         $success = TRUE;
       } catch (\Exception $e) {
         $progress = $this->runnableDone();
-        $this->task->onRunnableError($this->instance_state, $next_runnable, $e, $progress);
+        $this->task->onRunnableError($this->instance_state, $next_runnable, $e, $aggregator, $progress);
         $this->controller->onRunnableError($next_runnable, $e, $progress);
       }
 

--- a/src/TaskInterface.php
+++ b/src/TaskInterface.php
@@ -34,7 +34,7 @@ interface TaskInterface {
 
   function onRunnableComplete(TaskInstanceStateInterface $schedule, RunnableInterface $runnable, $result, RunnableResultAggregatorInterface $aggregator, ProgressInfo $progress);
 
-  function onRunnableError(TaskInstanceStateInterface $schedule, RunnableInterface $runnable, $exception, ProgressInfo $progress);
+  function onRunnableError(TaskInstanceStateInterface $schedule, RunnableInterface $runnable, $exception, RunnableResultAggregatorInterface $aggregator, ProgressInfo $progress);
 
   /**
    * Whether the Task is able to transform sets of Runnable results into a

--- a/tests/Mocks/TaskMock.php
+++ b/tests/Mocks/TaskMock.php
@@ -76,7 +76,7 @@ class TaskMock implements TaskInterface {
     return count($aggregator->getCollectedResults());
   }
 
-  public function onRunnableError(TaskInstanceStateInterface $instance_state, RunnableInterface $runnable, $exception, ProgressInfo $progress) {
+  public function onRunnableError(TaskInstanceStateInterface $instance_state, RunnableInterface $runnable, $exception, RunnableResultAggregatorInterface $aggregator, ProgressInfo $progress) {
     $this->num_on_error++;
   }
 


### PR DESCRIPTION
This is intended to make it possible for the Task classes implementation of onRunnableError()
to add a result in lieu of the successful runnable, or otherwise manipulate the collected
results in repsonse to the error.

If I'd created releases yet this would be a BC break, but since I haven't... :)